### PR TITLE
fix: 🐛 runtime error for stream selection enter confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![written in typescript](https://img.shields.io/badge/written%20in-typescript-blue.svg)](https://www.typescriptlang.org) [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-yellow.svg)](https://github.com/prettier/prettier) [![tested with jest](https://img.shields.io/badge/tested_with-jest-99424f.svg)](https://facebook.github.io/jest/) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/) [![yarn](https://img.shields.io/badge/maintained%20with-yarn-cc00ff.svg)](https://yarnpkg.com/en/)
 
-The Query Creator is an open source point-and-click interface for querying your event data. It's maintained by the team at [Keen IO](https://keen.io/).
+The Query Creator is an open source point-and-click interface used to create Keen Query structure. It's maintained by the team at [Keen IO](https://keen.io/).
 
 <img width="100%" src="https://user-images.githubusercontent.com/23423731/99073586-790b6e80-25b6-11eb-8d9a-0ed493cc3744.png">
 
@@ -18,9 +18,7 @@ or
 yarn add query-creator
 ```
 
-### Translations
-
-The default translations files for application are hosted on `jsdelivr` CDN. You can easily replace the translations by overriding the `loadPath` for files.
+### Integration
 
 ```typescript
 <QueryCreator
@@ -29,13 +27,8 @@ The default translations files for application are hosted on `jsdelivr` CDN. You
   readKey={readKey}
   masterKey={masterKey}
   host={host}
-  onUpdateQuery={this.onUpdateQuery}
-  onUpdateChartSettings={this.onUpdateChartSettings}
-  translations: {
-    backend: {
-      loadPath: 'https://cdn.jsdelivr.net/npm/@keen.io/explorer@$VERSION/dist/locales/{{lng}}/{{ns}}.json'
-    }
-  }
+  onUpdateQuery={(query) => {}}
+  onUpdateChartSettings={(chartSettings) => {}}
 />
 ```
 
@@ -57,4 +50,3 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org) to
 | Command      | Description                        |
 | ------------ | ---------------------------------- |
 | `npx git-cz` | run commit command line interface. |
-

--- a/src/components/EventCollection/EventCollection.tsx
+++ b/src/components/EventCollection/EventCollection.tsx
@@ -70,8 +70,10 @@ const EventCollection: FC<Props> = ({
       const { current: optionsList } = collectionListRef;
       switch (e.keyCode) {
         case KEYBOARD_KEYS.ENTER:
-          const { value } = optionsList[selectionIndexRef.current];
-          onChange(value);
+          if (optionsList && optionsList.length) {
+            const { value } = optionsList[selectionIndexRef.current];
+            onChange(value);
+          }
           setOpen(false);
           break;
         case KEYBOARD_KEYS.UP:

--- a/src/components/Interval/Interval.tsx
+++ b/src/components/Interval/Interval.tsx
@@ -1,10 +1,4 @@
-import React, {
-  FC,
-  useState,
-  useEffect,
-  useCallback,
-  useRef,
-} from 'react';
+import React, { FC, useState, useEffect, useCallback, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { ActionButton, Dropdown } from '@keen.io/ui-core';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import {
   SET_QUERY_EVENT,
   NEW_QUERY_EVENT,
   UPDATE_VISUALIZATION_TYPE,
-  SET_CHART_SETTINGS
+  SET_CHART_SETTINGS,
 } from './constants';
 import { TIMEZONES } from './components/Timezone/constants';
 import { getTimezoneValue } from './components/Timezone/utils/getTimezoneValue';


### PR DESCRIPTION
The issue occurs when event stream collection is empty and user hit _ENTER_ key.