### PR TITLE
fix: 🐛 support contains/not_contains operator for lists

### DIFF
--- a/src/components/Filters/constants.ts
+++ b/src/components/Filters/constants.ts
@@ -173,6 +173,16 @@ export const TYPES_CONFIG: Record<
       defaultValue: '',
       component: 'boolean-switcher',
     },
+    contains: {
+      label: 'contains',
+      defaultValue: '',
+      component: 'input-text',
+    },
+    not_contains: {
+      label: 'does not contain',
+      defaultValue: '',
+      component: 'input-text',
+    },
     ...ABSTRACT_OPERATORS,
   },
   Boolean: {


### PR DESCRIPTION
API now supports contains/not_contains operator for properties containing lists. Added support on UI to allow for filtering using contains/not_contains on lists.